### PR TITLE
Solved the problem with mixed city results

### DIFF
--- a/city_desc.py
+++ b/city_desc.py
@@ -1,33 +1,27 @@
 import external
 import requests
 
-"""
-Return description of the city, uses wiki as v0
-"""
-select_second_article = ['New York']
 
-def _get(city_name):
-    articles = get_wiki(city_name)
-    # if 'New York' select second articles
-    if (city_name in select_second_article):
-        title = articles[1][1]
-        text = articles[2][1]
-        url = articles[3][1]
-    # otherwise select first article
+"""
+Use the Wikipedia API to retrieve a description for the given City
+"""
+def get_city_description(city_name, country_name):
+    articles = external._lookup_wikipedia(city_name, country_name)
+
+    if city_name in _known_result_indices:
+        index = _known_result_indices['city_name']
     else:
-        title = articles[1][0]
-        text = articles[2][0]
-        url = articles[3][0]
-    response = {'title': title, 'text': text, 'url': url}
-    return response
+        index = 0  # use first result
 
-
-def get_wiki(city_name):
-    url = 'https://en.wikipedia.org/w/api.php'
-    params = {
-        'action': 'opensearch',
-        'search': city_name,
-        'format': 'json'
+    return {
+        'title': articles[1][index],
+        'text': articles[2][index],
+        'url': articles[3][index]
     }
-    response = requests.get(url, params=params).json()
-    return response
+
+
+# cities that are found in a particular search result index
+_known_result_indices = {
+    'New York': 1
+}
+

--- a/external.py
+++ b/external.py
@@ -175,8 +175,8 @@ def _lookup_time(location):
 """
 Use twitter API and oauth2 authetication to obtain twitter search results
 """
-def _lookup_twitter(city):
-    return twitter.get_twitter(city)
+def _lookup_twitter(city, location):
+    return twitter.get_twitter(city, location)
 
 
 """

--- a/external.py
+++ b/external.py
@@ -114,12 +114,13 @@ def _lookup_weather(location):
 Use the Wikipedia API to retrieve information for the given city.
 Returns a dictionary on success, None on failure.
 """
-def _lookup_wikipedia(city_name):
+def _lookup_wikipedia(city_name, country_name):
     url = 'https://en.wikipedia.org/w/api.php'
     params = {
         'action': 'opensearch',
-        'search': city_name,
-        'format': 'json'
+        'search': city_name + ', ' + country_name,
+        'format': 'json',
+        'redirects': 'resolve'  # necessary to handle page redirects
     }
 
     return _make_request(url, params)
@@ -129,12 +130,12 @@ def _lookup_wikipedia(city_name):
 Use the New York Times API to retrieve news information for the given city.
 Returns a dictionary on success, None on failure.
 """
-def _lookup_nyt(city_name):
+def _lookup_nyt(city_name, country_name):
     NYT_API_KEY = '532e9278d93c9c359096abdbbf5d65fd:14:74311752'
 
     url = 'http://api.nytimes.com/svc/search/v2/articlesearch.json'
     params = {
-        'q': city_name,
+        'q': city_name + ' ' + country_name,
         'sort': 'newest',
         'api-key': NYT_API_KEY,
     }

--- a/index.py
+++ b/index.py
@@ -73,16 +73,18 @@ def weather_json():
 @app.route('/wiki-json', methods=['GET'])
 def wiki_json():
     city_name = request.args.get('city')
+    country_name = request.args.get('country')
 
-    result = external._lookup_wikipedia(city_name)
+    result = external._lookup_wikipedia(city_name, country_name)
     return jsonify({'wiki-json': result})
 
 # return NYT json
 @app.route('/nyt-json', methods=['GET'])
 def nyt_json():
     city_name = request.args.get('city')
+    country_name = request.args.get('country')
 
-    result = external._lookup_nyt(city_name)
+    result = external._lookup_nyt(city_name, country_name)
     return jsonify({'nyt-json': result})
 
 # return current time json
@@ -93,6 +95,9 @@ def time_json():
     location = Location(lat,lng)
     
     local_time = external._lookup_time(location)
+
+    if local_time is None:
+        return jsonify(None)
 
     return jsonify({
         'time':      local_time.as_string(),
@@ -116,8 +121,9 @@ def autocomplete():
 # return city description json
 @app.route('/city-description', methods=['GET'])
 def city_description():
-    city = request.args.get('city')
-    response = city_desc._get(city)
+    city_name = request.args.get('city')
+    country_name = request.args.get('country')
+    response = city_desc.get_city_description(city_name, country_name)
     return json.dumps(response)
 
 

--- a/index.py
+++ b/index.py
@@ -125,7 +125,11 @@ def city_description():
 @app.route('/twitter-json', methods=['GET'])
 def twitter_json():
     city = request.args.get('city')
-    result = external._lookup_twitter(city)
+    lat = request.args.get('lat')
+    lng = request.args.get('lng')
+    location = Location(lat,lng)
+    
+    result = external._lookup_twitter(city, location)
     return jsonify({'twitter-json': result})
 
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -39,11 +39,13 @@ var updateCityTitle = function() {
 
 // given the city name, update description in jumbotron
 var updateCityDescription = function() {
-
     // Make a request for the description.
     var setText = function() {
+       var city = currentCity.name;
+       var country = currentCity.country;
+
        $.ajax({
-	   url: "city-description?" + 'city=' + currentCity.name,
+	   url: 'city-description?city=' + city + '&country=' + country,
 	   dataType: "json",
 	   success: function(response) {
 	       $('#city-description').empty();
@@ -69,42 +71,43 @@ var updateCityDescription = function() {
 // ------------------------------------------------------------------------
 // updateWiki updates #wiki-accordion with wiki search articles
 var updateWiki = function() {
-    var city = currentCity.name;
-
     // update screen using resource
     var updateWikiScreen = function(response) {
-	$('#wiki-accordion').empty();
-	if (response[1].length != 0) {	 	    
-	    for (i = 0; i < response[1].length; i++) {
-		// parse response and update wiki-accordion
-		var title = response[1][i];
-		var contents = response[2][i] + '<a href="' + 
-		    response[3][i] + '" target="_blank"> [details]</a>';
-		var collapse = (i < 2) ? " in" : ""; // open first two tabs
-		$('#wiki-accordion').append('<div class="panel panel-primary">' +
-					    '<div class="panel-heading">' +
-					    '<h4 class="panel-title">' +
-					    '<a data-toggle="collapse" data-parent="#accordion"' + 
-					    'href="#collapse-wiki' + i + '">' +
-					    title + '</a></h4></div>' +
-					    '<div id="collapse-wiki' + i + 
-					    '" class="panel-collapse collapse' + collapse  + '">' +
-					    '<div class="panel-body"><p>' +
-					    contents + '</p></div></div></div>');
-	    }
-	}
-	else {
-	    $('#wiki-accordion').empty();
-	    $('#wiki-accordion').append('<div class="panel panel-warning">' +
-					'<div class="panel-heading">' +
-					'<h4 class="panel-title">' +
-					'No Wiki articles - invalid input</h4></div></div>');
-	}
+        $('#wiki-accordion').empty();
+        if (response[1].length != 0) {	 	    
+            for (i = 0; i < response[1].length; i++) {
+            // parse response and update wiki-accordion
+            var title = response[1][i];
+            var details_link = response[2][i] + '<a href="' + 
+                response[3][i] + '" target="_blank"> [details]</a>';
+            var collapse = (i < 2) ? " in" : ""; // open first two tabs
+            $('#wiki-accordion').append('<div class="panel panel-primary">' +
+                            '<div class="panel-heading">' +
+                            '<h4 class="panel-title">' +
+                            '<a data-toggle="collapse" data-parent="#accordion"' + 
+                            'href="#collapse-wiki' + i + '">' +
+                            title + '</a></h4></div>' +
+                            '<div id="collapse-wiki' + i + 
+                            '" class="panel-collapse collapse' + collapse  + '">' +
+                            '<div class="panel-body"><p>' +
+                            details_link + '</p></div></div></div>');
+            }
+        }
+        else {
+            $('#wiki-accordion').empty();
+            $('#wiki-accordion').append('<div class="panel panel-warning">' +
+                        '<div class="panel-heading">' +
+                        '<h4 class="panel-title">' +
+                        'No Wiki articles - invalid input</h4></div></div>');
+        }
     };
+
+    var city = currentCity.name;
+    var country = currentCity.country;
 
     // request resource
     $.ajax({
-	url: "wiki-json?" + 'city=' + city,
+	url: 'wiki-json?city=' + city + '&country=' + country,
 	dataType: "json",
 	success: function(response) {
 	    updateWikiScreen(response['wiki-json']);
@@ -171,39 +174,39 @@ var updateTwitter = function() {
 var updateNYT = function() {
     // update screen using resource
     var updateNYTScreen = function(response) {
-	//console.log(response['response']['docs']);
-	$('#nyt-accordion').empty();
-	if (response['response']['docs'].length != 0) {	 
-	    for (i = 0; i < response['response']['docs'].length; i++) {
-		var article = response['response']['docs'][i]
-		var title = article['headline']['main'];
-		var contents = article['snippet'] + '<a href="' + 
-		    article['web_url'] + '" target="_blank"> [details]</a>';
-		var collapse = (i < 5) ? " in" : ""; // open 5 tabs
-		$('#nyt-accordion').append('<div class="panel panel-primary">' +
-					    '<div class="panel-heading">' +
-					    '<h4 class="panel-title">' +
-					    '<a data-toggle="collapse" data-parent="#accordion"' + 
-					    'href="#collapse-nyt' + i + '">' +
-					    title + '</a></h4></div>' +
-					    '<div id="collapse-nyt' + i + 
-					    '" class="panel-collapse collapse' + collapse  + '">' +
-					    '<div class="panel-body"><p>' +
-					    contents + '</p></div></div></div>');
-	    }
-	}
-	else {
-	    $('#nyt-accordion').append('<div class="panel panel-warning">' +
-					'<div class="panel-heading">' +
-					'<h4 class="panel-title">' +
-					'No NYT articles - invalid input</h4></div></div>');
-	}
-	
+        $('#nyt-accordion').empty();
+        if (response['response']['docs'].length != 0) {	 
+            for (i = 0; i < response['response']['docs'].length; i++) {
+            var article = response['response']['docs'][i]
+            var title = article['headline']['main'];
+            var contents = article['snippet'] + '<a href="' + 
+                article['web_url'] + '" target="_blank"> [details]</a>';
+            var collapse = (i < 5) ? " in" : ""; // open 5 tabs
+            $('#nyt-accordion').append('<div class="panel panel-primary">' +
+                            '<div class="panel-heading">' +
+                            '<h4 class="panel-title">' +
+                            '<a data-toggle="collapse" data-parent="#accordion"' + 
+                            'href="#collapse-nyt' + i + '">' +
+                            title + '</a></h4></div>' +
+                            '<div id="collapse-nyt' + i + 
+                            '" class="panel-collapse collapse' + collapse  + '">' +
+                            '<div class="panel-body"><p>' +
+                            contents + '</p></div></div></div>');
+            }
+        } else {
+            $('#nyt-accordion').append('<div class="panel panel-warning">' +
+                        '<div class="panel-heading">' +
+                        '<h4 class="panel-title">' +
+                        'No NYT articles - invalid input</h4></div></div>');
+        }
     };
+
+    var city = currentCity.name;
+    var country = currentCity.country;
 
     // request resource
     $.ajax({
-	url: 'nyt-json?' + 'city=' + currentCity.name + ' ' + currentCity.country,
+	url: 'nyt-json?city=' + city + '&country=' + country,
 	dataType: 'json',
 	success: function(response) {
 	    updateNYTScreen(response['nyt-json']);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -123,12 +123,14 @@ var updateWiki = function() {
 // Update twitter feed
 var updateTwitter = function() {
     var city = currentCity.name;
+    var lat = currentCity.loc['lat'];
+    var lng = currentCity.loc['lng'];
     // empty targets
     $('#twitter-content').empty();
     $('#twitter-link').empty();
     // Make a request for the description.
    $.ajax({
-       url: "twitter-json?" + 'city=' + city,
+       url: "twitter-json?" + 'city=' + city + '&lat=' + lat + '&lng=' + lng,
        dataType: "json",
        success: function(response) {
 	   $('#twitter-link').append('<a href="https://twitter.com/search?q=' + city + '" target="_blank">' +

--- a/twitter.py
+++ b/twitter.py
@@ -9,11 +9,17 @@ from sensitive_text import sensitive_text
 """
 Use twitter API and oauth2 authetication to obtain twitter search results
 """
-def get_twitter(city):
+def get_twitter(city, location):
     if city not in valid_cities.twitter_ban: #city in valid_cities.tested_list:
-        query = city
+        geo_string = ','.join([str(location.lat), str(location.lng), '50mi'])
         count = '130'
-        url = 'https://api.twitter.com/1.1/search/tweets.json?q=%23' + query + '&count=' + count
+        param_string = ''.join([
+                        '?q=%23', city,           # search for "#city"
+                        '&geocode=', geo_string,  # constrain using geolocation
+                        '&count=', count,         # limit the number of results
+                        '&lang=en'                # English language
+                        ])
+        url = 'https://api.twitter.com/1.1/search/tweets.json' + param_string
         key = '4898127648-hImwrcGlSCMqYvKIFl5BCZXAZAWunJ7FAtsrHYO'
         secret = 'BcvtY6dYTlzFboKjQXtfaQYGHNZrZSJebzA3FzQVdXSiq'
         return oauth_req(url, key, secret)
@@ -64,4 +70,3 @@ def parse_twitter(raw):
         except:
             pass #possible sensitive content
     return response
-


### PR DESCRIPTION
I made these changes in response to the mixed city results for Birmingham. I believe we should now have far fewer cases of incorrect results.

The main improvement is that the Twitter display will now only include results that originated within a 50-mile radius of the city. This should prevent the page from Birmingham, Alabama from showing tweets from Birmingham, England.

This pull request also includes an improvement to our use of the Wikipedia API, so the city description should be much less likely to show incorrect results.